### PR TITLE
Clean up `pom.xml` to reduce warnings

### DIFF
--- a/jNut/pom.xml
+++ b/jNut/pom.xml
@@ -24,11 +24,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.15.0</version>
-                <configuration>
-                    <source>${java.source.level}</source>
-                    <target>${java.target.level}</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/jNutList/pom.xml
+++ b/jNutList/pom.xml
@@ -55,11 +55,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.15.0</version>
-        <configuration>
-          <source>${java.source.level}</source>
-          <target>${java.target.level}</target>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/jNutWebAPI/pom.xml
+++ b/jNutWebAPI/pom.xml
@@ -44,10 +44,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.15.0</version>
                 <configuration>
-                    <source>${java.source.level}</source>
-                    <target>${java.target.level}</target>
                     <compilerArguments>
                         <endorseddirs>${endorsed.dir}</endorseddirs>
                     </compilerArguments>

--- a/jNutWebAPI/pom.xml
+++ b/jNutWebAPI/pom.xml
@@ -45,9 +45,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <compilerArguments>
-                        <endorseddirs>${endorsed.dir}</endorseddirs>
-                    </compilerArguments>
+                    <compilerArgs combine.children="append">
+                        <arg>-Djava.endorsed.dirs=${endorsed.dir}</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/jNutWebAPI/pom.xml
+++ b/jNutWebAPI/pom.xml
@@ -70,7 +70,7 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${endorsed.dir}</outputDirectory>
-                            <silent>true</silent>
+                            <!-- silent>true</silent -->
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>javax</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.15.0</version>
+                    <configuration>
+                        <compilerArgs>
+                            <!-- Suppress warnings about obsolete
+                                 Java versions during the build: -->
+                            <arg>-Xlint:-options</arg>
+                        </compilerArgs>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,25 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- NOTE: For ancient system builds, 1.4 or 1.6 may be still viable;
          current compilers in 2020's do not accept those values anymore.
+          <java.source.level>1.6</java.source.level>
+          <java.target.level>1.6</java.target.level>
       -->
-    <java.source.level>8</java.source.level>
-    <java.target.level>8</java.target.level>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
-  <dependencyManagement>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.15.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
NOTE: The "restricted method" and "terminally deprecated method" warnings (related to `JansiLoader` and `sun.misc.Unsafe`) come from Maven's own libraries (Jansi and Guava) when running on a newer JDK and cannot be fixed by project-level POM changes. They are external to this project's code.