### PR TITLE
Potential fixes for code scanning alerts

### DIFF
--- a/jNut/src/main/java/org/networkupstools/jnut/Scanner.java
+++ b/jNut/src/main/java/org/networkupstools/jnut/Scanner.java
@@ -278,7 +278,7 @@ public class Scanner {
      * @return Value of the parameter, null if not found.
      */
     public String getParam(String name) {
-        if (config == null) {
+        if (config != null) {
             return (String)config.get(name);
         }
         return null;
@@ -290,7 +290,7 @@ public class Scanner {
      * @return True if the scanner has the parameter set.
      */
     public boolean hasParam(String name) {
-        if (config == null) {
+        if (config != null) {
             return config.get(name)!=null;
         }
         return false;

--- a/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/NutRestProvider.java
+++ b/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/NutRestProvider.java
@@ -63,8 +63,15 @@ public class NutRestProvider {
             int idx = server.indexOf(':');
             if(idx!=-1)
             {
-                int port = Integer.parseInt(server.substring(idx+1));
-                client.connect(server.substring(0, idx), port);
+                String host = server.substring(0, idx);
+                String portPart = server.substring(idx+1);
+                try {
+                    int port = Integer.parseInt(portPart);
+                    client.connect(host, port);
+                } catch (NumberFormatException ex) {
+                    Logger.getLogger(NutRestProvider.class.getName()).log(Level.WARNING, "Invalid port in server parameter: " + server + ". Falling back to default port 3493.", ex);
+                    client.connect(host, 3493);
+                }
             }
             else
             {

--- a/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/NutRestProvider.java
+++ b/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/NutRestProvider.java
@@ -69,7 +69,8 @@ public class NutRestProvider {
                     int port = Integer.parseInt(portPart);
                     client.connect(host, port);
                 } catch (NumberFormatException ex) {
-                    Logger.getLogger(NutRestProvider.class.getName()).log(Level.WARNING, "Invalid port in server parameter: " + server + ". Falling back to default port 3493.", ex);
+                    String sanitizedServer = server.replace('\n', '_').replace('\r', '_');
+                    Logger.getLogger(NutRestProvider.class.getName()).log(Level.WARNING, "Invalid port in server parameter: " + sanitizedServer + ". Falling back to default port 3493.", ex);
                     client.connect(host, 3493);
                 }
             }


### PR DESCRIPTION
Potential fix for [https://github.com/networkupstools/jNut/security/code-scanning/23](https://github.com/networkupstools/jNut/security/code-scanning/23)

Catch `NumberFormatException` around the port parsing in `Server(String server)` and fall back to the existing default port (`3493`) so behavior remains stable and the constructor does not fail purely due to malformed port text.

Best single fix in this file:
- Edit `jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/NutRestProvider.java`
- In `Server` constructor, replace direct `Integer.parseInt(...)` call with a `try/catch (NumberFormatException)` block.
- On parse failure, log a warning and connect using default port `3493`.
- No new dependencies are needed; existing `Logger`/`Level` imports already support logging.

Potential fix for [https://github.com/networkupstools/jNut/security/code-scanning/10](https://github.com/networkupstools/jNut/security/code-scanning/10) and [https://github.com/networkupstools/jNut/security/code-scanning/11](https://github.com/networkupstools/jNut/security/code-scanning/11): the (non)-nullness check for `config` value we look into got inverted

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
