### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled command line

### DIFF
--- a/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/ScannerProvider.java
+++ b/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/ScannerProvider.java
@@ -19,6 +19,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 package org.networkupstools.jnutwebapi;
 
 import java.io.IOException;
+import java.util.regex.Pattern;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -40,6 +41,23 @@ import org.networkupstools.jnut.Scanner.DiscoveredDevice;
 public class ScannerProvider {
     static final String execName = "/usr/local/ups/bin/nut-scanner";
     static final String execPath = "";
+    private static final Pattern IPV4_PATTERN = Pattern.compile("^(25[0-5]|2[0-4]\\\\d|1\\\\d\\\\d|[1-9]?\\\\d)(\\\\.(25[0-5]|2[0-4]\\\\d|1\\\\d\\\\d|[1-9]?\\\\d)){3}$");
+    private static final Pattern CIDR_PATTERN = Pattern.compile("^([0-9]|[1-2][0-9]|3[0-2])$");
+
+    private static boolean isValidIPv4(String value) {
+        return value != null && IPV4_PATTERN.matcher(value).matches();
+    }
+
+    private static boolean isValidMask(String value) {
+        if (value == null) {
+            return false;
+        }
+        String[] parts = value.split("/", -1);
+        if (parts.length == 2) {
+            return isValidIPv4(parts[0]) && CIDR_PATTERN.matcher(parts[1]).matches();
+        }
+        return isValidIPv4(value);
+    }
 
     @GET
     @Produces("application/json")
@@ -53,12 +71,24 @@ public class ScannerProvider {
             scan.setExecName(execName);
         if(execPath!=null && execPath.length()>0)
             scan.setExecPath(execPath);
-        if(start!=null && start.length()>0)
+        if(start!=null && start.length()>0) {
+            if (!isValidIPv4(start)) {
+                throw new WebApplicationException(400);
+            }
             scan.setParam(Scanner.OPTION_START_IP, start);
-        if(end!=null && end.length()>0)
+        }
+        if(end!=null && end.length()>0) {
+            if (!isValidIPv4(end)) {
+                throw new WebApplicationException(400);
+            }
             scan.setParam(Scanner.OPTION_END_IP, end);
-        if(mask!=null && mask.length()>0)
+        }
+        if(mask!=null && mask.length()>0) {
+            if (!isValidMask(mask)) {
+                throw new WebApplicationException(400);
+            }
             scan.setParam(Scanner.OPTION_MASK_CIDR, mask);
+        }
 
         try {
             DiscoveredDevice[] devs = scan.scan();


### PR DESCRIPTION
Potential fix for [https://github.com/networkupstools/jNut/security/code-scanning/4](https://github.com/networkupstools/jNut/security/code-scanning/4)

Validate and constrain all user-controlled scanner arguments at the API boundary before calling `scan.setParam(...)`. The best fix here is strict allowlist validation for expected formats:

- `start` and `end`: IPv4 address format only.
- `mask`: either CIDR (`0-32`) or IPv4 netmask format.

If validation fails, reject request with HTTP 400 (`WebApplicationException(400)`). This preserves intended functionality (valid scan requests still work) while blocking malformed/hostile values from ever reaching `Runtime.exec(...)`.

Apply changes only in:

- `jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/ScannerProvider.java`
  - Add `java.util.regex.Pattern` import.
  - Add compiled regex constants and helper methods in class.
  - Replace the three `setParam` conditionals to validate before setting and throw `WebApplicationException(400)` on invalid input.

No change is required in `Scanner.java` for this specific taint path once inputs are validated at source.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
