### PR TITLE
Potential fix for code scanning alert no. 3: Server-side request forgery

### DIFF
--- a/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/NutRestProvider.java
+++ b/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/NutRestProvider.java
@@ -54,7 +54,9 @@ public class NutRestProvider {
     }
 
     public static Set<String> getAllowedServerHosts() {
-        return ((HashSet)(ALLOWED_UPSD_HOSTS)).clone();
+        Set<String> retval = new HashSet<String>();
+        retval.addAll(ALLOWED_UPSD_HOSTS);
+        return retval;
     }
 
     public static void addAllowedServerHost(String host) {

--- a/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/NutRestProvider.java
+++ b/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/NutRestProvider.java
@@ -49,8 +49,22 @@ public class NutRestProvider {
             "localhost"
     ));
 
-    private static boolean isAllowedServerHost(String host) {
+    public static boolean isAllowedServerHost(String host) {
         return host != null && ALLOWED_UPSD_HOSTS.contains(host);
+    }
+
+    public static Set<String> getAllowedServerHosts() {
+        return ALLOWED_UPSD_HOSTS.clone();
+    }
+
+    public static void addAllowedServerHost(String host) {
+        if (host != null)
+            ALLOWED_UPSD_HOSTS.add(host);
+    }
+
+    public static void removeAllowedServerHost(String host) {
+        if (host != null)
+            ALLOWED_UPSD_HOSTS.remove(host);
     }
 
     @GET

--- a/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/NutRestProvider.java
+++ b/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/NutRestProvider.java
@@ -20,6 +20,9 @@ package org.networkupstools.jnutwebapi;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -40,6 +43,15 @@ import org.networkupstools.jnut.Variable;
  */
 @Path("/servers")
 public class NutRestProvider {
+
+    private static final Set<String> ALLOWED_UPSD_HOSTS = new HashSet<String>(Arrays.asList(
+            "127.0.0.1",
+            "localhost"
+    ));
+
+    private static boolean isAllowedServerHost(String host) {
+        return host != null && ALLOWED_UPSD_HOSTS.contains(host);
+    }
 
     @GET
     public String get() {
@@ -64,6 +76,9 @@ public class NutRestProvider {
             if(idx!=-1)
             {
                 String host = server.substring(0, idx);
+                if (!isAllowedServerHost(host)) {
+                    throw new IllegalArgumentException("Server host is not allowed");
+                }
                 String portPart = server.substring(idx+1);
                 try {
                     int port = Integer.parseInt(portPart);
@@ -76,6 +91,9 @@ public class NutRestProvider {
             }
             else
             {
+                if (!isAllowedServerHost(server)) {
+                    throw new IllegalArgumentException("Server host is not allowed");
+                }
                 client.connect(server, 3493);
             }
         }

--- a/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/NutRestProvider.java
+++ b/jNutWebAPI/src/main/java/org/networkupstools/jnutwebapi/NutRestProvider.java
@@ -54,7 +54,7 @@ public class NutRestProvider {
     }
 
     public static Set<String> getAllowedServerHosts() {
-        return ALLOWED_UPSD_HOSTS.clone();
+        return ((HashSet)(ALLOWED_UPSD_HOSTS)).clone();
     }
 
     public static void addAllowedServerHost(String host) {


### PR DESCRIPTION
Potential fix for [https://github.com/networkupstools/jNut/security/code-scanning/3](https://github.com/networkupstools/jNut/security/code-scanning/3)

To fix this without changing intended behavior more than necessary, validate the `server` path parameter against a strict server-side allowlist before any connection attempt. The best location is `NutRestProvider.Server(String server)` because it is the trust boundary entry-point and already parses host/port.

Implement:
- A static allowlist of permitted UPSD hostnames/IPs in `NutRestProvider`.
- A helper method that validates host membership in the allowlist.
- In the `Server` constructor, after parsing host (or using whole `server` when no port given), reject non-allowed hosts with `IllegalArgumentException`.
- Keep existing port parsing/fallback behavior unchanged.

This preserves current functionality for approved hosts while preventing attacker-controlled arbitrary destinations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

TODO: This would want a config file or CLI argument support to add permitted hosts on the fly. API to do so is here.