### PR TITLE
Potential fix for code scanning alert no. 12: Potential input resource leak

### DIFF
--- a/jNut/src/main/java/org/networkupstools/jnut/Scanner.java
+++ b/jNut/src/main/java/org/networkupstools/jnut/Scanner.java
@@ -360,13 +360,14 @@ public class Scanner {
      */
     DiscoveredDevice[] processScanResult(Process process) throws IOException {
         List/*<DiscoveredDevice>*/ list = new ArrayList/*<DiscoveredDevice>*/();
-        InputStream is = process.getInputStream();
-        BufferedReader in = new BufferedReader(new InputStreamReader(is));
-        String line;
-        for (line = in.readLine(); line != null; line = in.readLine()) {
-            DiscoveredDevice dev = scanLine(line);
-            if (dev != null) {
-                list.add(dev);
+        try (InputStream is = process.getInputStream();
+                BufferedReader in = new BufferedReader(new InputStreamReader(is))) {
+            String line;
+            for (line = in.readLine(); line != null; line = in.readLine()) {
+                DiscoveredDevice dev = scanLine(line);
+                if (dev != null) {
+                    list.add(dev);
+                }
             }
         }
         return (DiscoveredDevice[]) list.toArray(new DiscoveredDevice[list.size()]);


### PR DESCRIPTION
Potential fix for [https://github.com/networkupstools/jNut/security/code-scanning/12](https://github.com/networkupstools/jNut/security/code-scanning/12)

Use try-with-resources in `processScanResult(Process process)` so the stream/reader are always closed, including when exceptions occur. The best minimal fix is to declare the `InputStream` and `BufferedReader` in the try-with-resources header and keep the existing parsing logic unchanged inside. Closing `BufferedReader` will close its wrapped `InputStreamReader`, and closing that closes the underlying `InputStream`; declaring both explicitly is still clear and safe.

Change region: `jNut/src/main/java/org/networkupstools/jnut/Scanner.java`, method `processScanResult(Process process)` around current lines 363–371. No new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
