### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/jNut/src/main/java/org/networkupstools/jnut/Scanner.java
+++ b/jNut/src/main/java/org/networkupstools/jnut/Scanner.java
@@ -328,8 +328,16 @@ public class Scanner {
             File dir = null;
 
             if (localExecPath != null && !localExecPath.isEmpty()) {
-                dir = new File(localExecPath);
-                if (!dir.exists() || !dir.isDirectory()) {
+                try {
+                    if (localExecPath.contains("..")) {
+                        dir = null;
+                    } else {
+                        File candidate = new File(localExecPath).getCanonicalFile();
+                        if (candidate.exists() && candidate.isDirectory()) {
+                            dir = candidate;
+                        }
+                    }
+                } catch (IOException e) {
                     dir = null;
                 }
             }


### PR DESCRIPTION
Potential fix for [https://github.com/networkupstools/jNut/security/code-scanning/2](https://github.com/networkupstools/jNut/security/code-scanning/2)

General fix approach: enforce strict validation at the sink boundary (where the path is consumed) so only safe working directories are accepted. Relying on callers to always sanitize is fragile, especially with a generic `setParam` API.

Best fix here: in `jNut/src/main/java/org/networkupstools/jnut/Scanner.java`, validate `localExecPath` in `scan()` before creating/using `File dir`. Reject path traversal patterns (`..`), and require a canonical existing directory. If validation fails, ignore the provided path and fall back to `runtime.exec(params)` (current behavior when `dir == null`), preserving functionality while removing unsafe path usage. No behavior change for valid configured paths.

Concretely:
- Edit the `scan()` block around current lines 330–334.
- Add canonical-path-based validation (`getCanonicalFile()`), reject values containing `..`, and ensure directory exists/isDirectory.
- Catch `IOException` from canonicalization and treat as invalid (`dir = null`).
- No new dependency is needed; existing `java.io.*` imports already cover required classes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
